### PR TITLE
don't fail with enigmatic "ERROR: null"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,20 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.jenkins-ci.plugins</groupId>
-    <artifactId>plugin</artifactId>
-    <!-- Baseline Jenkins version you use to build and test the plugin. Users must have this version or newer to run. -->
-    <version>1.580.1</version>
-    <relativePath/>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>plugin</artifactId>
+      <version>2.30</version>
+      <relativePath />
   </parent>
+  <properties>
+      <jenkins.version>2.105</jenkins.version>
+      <java.level>8</java.level>
+       <maven.javadoc.skip>true</maven.javadoc.skip>
+  </properties>
+
   <groupId>com.typesafe.jenkins</groupId>
   <artifactId>ec2-start-stop</artifactId>
-  <version>0.0.0-SNAPSHOT</version>
+  <version>0.1.0</version>
   <packaging>hpi</packaging>
 
   <name>EC2 Start/Stop Plugin</name>
@@ -71,11 +76,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.2</version>
         <configuration>
-          <!-- put your configurations here -->
         </configuration>
       </plugin>
-
-
     </plugins>
   </build>
   

--- a/src/main/scala/EC2InstanceManager.scala
+++ b/src/main/scala/EC2InstanceManager.scala
@@ -78,7 +78,7 @@ object EC2InstanceManager {
     _ec2
   }
 
-  def instanceByName(name: String)(implicit logger: String => Unit = println): Option[Instance] = {
+  def instanceByName(name: String)(implicit logger: String => Unit = println): Option[Instance] = try {
     val instances =
       for {
         reservation <- ec2.describeInstances.getReservations.asScala
@@ -90,6 +90,10 @@ object EC2InstanceManager {
 
     if (instances.nonEmpty && instances.tail.nonEmpty) logger(s"Multiple instances found! $instances")
     instances.headOption
+  } catch {
+    case _ => 
+      logger(s"Couldn't find EC2 instance for $name")
+      None
   }
 
   def start(instanceIds: List[String]) =


### PR DESCRIPTION
when instance isn't found

built with `mvn  -DskipTests package `

see #4  (similar error, but this PR addresses the 0 instances issue)